### PR TITLE
Initialize paddle velocities as floats

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -23,9 +23,9 @@ class DemoGame:
             Paddle.HEIGHT,
         )
         self._paddle_center = float(self.paddle.centerx)
-        self.paddle_vx = 0
+        self.paddle_vx: float = 0.0
         self.balls = [create_ball()]  # start with a single ball
-        self.powerup = None
+        self.powerup: dict | None = None
 
     def update(self, dt: float) -> None:
         """Advance the demo simulation by one frame."""
@@ -33,12 +33,13 @@ class DemoGame:
         # Autopilot: track whichever ball will hit the paddle next. A small
         # random offset keeps the motion from looking too mechanical.
         if self.balls:
-            target_x = None
-            frames_left = None
+            target_x: float | None = None
+            frames_left: int | None = None
             for ball in self.balls:
                 tx, fl = self._predict_intercept(ball)
                 if frames_left is None or fl < frames_left:
                     target_x, frames_left = tx, fl
+            assert target_x is not None and frames_left is not None
             # Add a tiny offset each frame to avoid perfectly straight movement
             target_x += random.uniform(-2, 2)
 

--- a/game.py
+++ b/game.py
@@ -27,9 +27,9 @@ def run_game(screen, clock, font, debug_font) -> int:
     powerup = None           # there may or may not be a powerup present
     score = 0
 
-    paddle_vx = 0           # current horizontal velocity
-    paddle_target_vx = 0    # desired velocity based on input
-    paddle_start_vx = 0     # velocity at the start of a transition
+    paddle_vx: float = 0.0           # current horizontal velocity
+    paddle_target_vx: float = 0.0    # desired velocity based on input
+    paddle_start_vx: float = 0.0     # velocity at the start of a transition
     transition_t = 1.0      # progress of velocity transition
 
     while True:
@@ -66,7 +66,7 @@ def run_game(screen, clock, font, debug_font) -> int:
             paddle_vx = paddle_target_vx
 
         # Move the paddle and keep it on screen
-        paddle.x += paddle_vx
+        paddle.x = int(paddle.x + paddle_vx)
         paddle.clamp_ip(pygame.Rect(0, 0, Screen.WIDTH, Screen.HEIGHT))
 
         # Randomly spawn a powerup


### PR DESCRIPTION
## Summary
- store paddle velocity variables as floats
- type DemoGame attributes and ensure None checks
- clamp paddle updates using int to satisfy typing

## Testing
- `mypy --ignore-missing-imports .`
- `python main.py` *(runs until interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6861546c4ec8832fb4d3cfe31446a6e0