### PR TITLE
Add paddle size power-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Single Player Pong is a vertical-scrolling twist on the classic arcade game. Bui
 
 - Balls speed up after bouncing off the top wall or your paddle
 - Yellow power-ups briefly appear and duplicate any ball that passes through them
+- Blue power-ups enlarge your paddle for a short time, while red ones shrink it
 - The game ends only when every ball is missed
 
 ## Requirements

--- a/constants.py
+++ b/constants.py
@@ -39,5 +39,10 @@ class Powerup:
     DURATION = 8.0
     CHANCE = 0.005
 
+    # Paddle size modification
+    SIZE_DURATION = 6.0
+    ENLARGE_FACTOR = 1.5
+    SHRINK_FACTOR = 0.6
+
 
 __all__ = ["Screen", "Paddle", "Ball", "Powerup"]

--- a/entities.py
+++ b/entities.py
@@ -42,13 +42,23 @@ def create_ball(up: bool = False, pos: tuple[int, int] | None = None) -> dict:
 
 
 def spawn_powerup() -> dict:
-    """Create a powerup rectangle at a random location."""
+    """Create a powerup rectangle at a random location.
+
+    Randomly chooses between duplicating balls or modifying the paddle size.
+    The ``type`` field identifies which behaviour to apply when a ball hits it.
+    """
 
     # Position the powerup somewhere near the top half of the screen
     x = random.randint(20, Screen.WIDTH - Powerup.WIDTH - 20)
     y = random.randint(80, Screen.HEIGHT // 2)
     rect = pygame.Rect(x, y, Powerup.WIDTH, Powerup.HEIGHT)
 
-    # The ``collided`` set keeps track of balls already duplicated by this
-    # powerup
-    return {"rect": rect, "timer": Powerup.DURATION, "collided": set()}
+    p_type = random.choice(["duplicate", "paddle_big", "paddle_small"])
+
+    # The ``collided`` set keeps track of balls that have triggered this powerup
+    return {
+        "rect": rect,
+        "timer": Powerup.DURATION,
+        "collided": set(),
+        "type": p_type,
+    }


### PR DESCRIPTION
## Summary
- allow powerups to modify paddle size or duplicate balls
- show new powerups in blue (enlarge) and red (shrink)
- support paddle size effect in menu demo
- document the new powerups in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6862c8ed4830832f92484da2d459d368